### PR TITLE
Ensure label#for matches element#id (case-sensitive)

### DIFF
--- a/lib/sinatra/form_helpers.rb
+++ b/lib/sinatra/form_helpers.rb
@@ -45,7 +45,7 @@ module Sinatra
 
     # Form field label
     def label(obj, field, display = "", options={})
-      tag :label, (display.nil? || display == '') ? titleize(field.to_s) : display, options.merge(:for => "#{obj}_#{field}")
+      tag :label, (display.nil? || display == '') ? titleize(field.to_s) : display, options.merge(:for => css_id(obj, field))
     end
 
     # Form text input.  Specify the value as :value => 'foo'


### PR DESCRIPTION
Ensure that a label's `for` attribute matches the corresponding element's `id`. use the `css_id` method in both cases.

(css_id downcase's the id, so upper case fields cause problems)
